### PR TITLE
add comments for generating godoc, tweak some naming to conform with Go naming convention.

### DIFF
--- a/pkg/common/doc.go
+++ b/pkg/common/doc.go
@@ -1,0 +1,5 @@
+// Package common contains shared codes used by all other packages/contexts, but
+// PLEASE KEEP THIS COMMON PACKAGE SMALL!!!
+// Before adding codes in this package, think twice if it is so common that
+// it has to be added here.
+package common

--- a/pkg/common/error.go
+++ b/pkg/common/error.go
@@ -1,0 +1,8 @@
+package common
+
+import "github.com/pkg/errors"
+
+// These error codes are common errors happened in most packages.
+var (
+	ErrNotImpl = errors.Errorf("not implemented")
+)

--- a/pkg/metadata/album/album.go
+++ b/pkg/metadata/album/album.go
@@ -1,9 +1,12 @@
+// Package album contains domain models relating to albums.
 package album
 
 import "github.com/xiaomi388/virtual-music-system/pkg/metadata/song"
 
+// ID is the type of Album.ID.
 type ID string
 
+// Album contains metadata for a album, and the song ids of an album.
 type Album struct {
 	ID    ID
 	Name  string

--- a/pkg/metadata/album/repo.go
+++ b/pkg/metadata/album/repo.go
@@ -1,5 +1,6 @@
 package album
 
+// Repository contains Album entities.
 type Repository interface {
 	GetAlbum(id ID) (Album, error)
 	GetAlbumsByQuery(q string, limit int, offset int) (map[ID]Album, error)

--- a/pkg/metadata/artist/artist.go
+++ b/pkg/metadata/artist/artist.go
@@ -2,8 +2,11 @@ package artist
 
 import "github.com/xiaomi388/virtual-music-system/pkg/metadata/song"
 
+// ID is the type of Artist.ID
 type ID string
 
+// Artist represents an artist entity containing the basic info of
+// this artist and the ids of songs she created.
 type Artist struct {
 	ID    ID
 	Songs map[song.ID]struct{}

--- a/pkg/metadata/artist/repo.go
+++ b/pkg/metadata/artist/repo.go
@@ -1,5 +1,6 @@
 package artist
 
+// Repository contains Artist entities
 type Repository interface {
 	GetArtist(id ID) (Artist, error)
 	GetArtistsByQuery(q string, limit int, offset int) (map[ID]Artist, error)

--- a/pkg/metadata/doc.go
+++ b/pkg/metadata/doc.go
@@ -1,0 +1,3 @@
+// Package metadata contains business logic related to metadata of songs, artists,
+// albums and so on.
+package metadata

--- a/pkg/metadata/driver/netease/album.go
+++ b/pkg/metadata/driver/netease/album.go
@@ -1,17 +1,17 @@
 package netease
 
 import (
+	"github.com/xiaomi388/virtual-music-system/pkg/common"
 	"github.com/xiaomi388/virtual-music-system/pkg/metadata/album"
-	"github.com/xiaomi388/virtual-music-system/pkg/metadata/exception"
 )
 
 type AlbumRepository struct {
 }
 
 func (r *AlbumRepository) GetAlbum(id album.ID) (album.Album, error) {
-	return album.Album{}, new(exception.NotImplementedError)
+	return album.Album{}, common.ErrNotImpl
 }
 
 func (r *AlbumRepository) GetAlbumsByQuery(q string, limit int, offset int) (map[album.ID]album.Album, error) {
-	return nil, new(exception.NotImplementedError)
+	return nil, common.ErrNotImpl
 }

--- a/pkg/metadata/driver/netease/artist.go
+++ b/pkg/metadata/driver/netease/artist.go
@@ -1,18 +1,20 @@
 package netease
 
 import (
+	"github.com/xiaomi388/virtual-music-system/pkg/common"
 	"github.com/xiaomi388/virtual-music-system/pkg/metadata/artist"
-	"github.com/xiaomi388/virtual-music-system/pkg/metadata/exception"
 )
 
+// ArtistRepository retrieves artist metadata from netease API.
 type ArtistRepository struct {
 }
 
+// GetArtist retrieves the metadata of the artist of a specific id from netease API by.
 func (r *ArtistRepository) GetArtist(id artist.ID) (artist.Artist, error) {
-	return artist.Artist{}, new(exception.NotImplementedError)
+	return artist.Artist{}, common.ErrNotImpl
 }
 
 func (r *ArtistRepository) GetArtistsByQuery(
 	q string, limit int, offset int) (map[artist.ID]artist.Artist, error) {
-	return nil, new(exception.NotImplementedError)
+	return nil, common.ErrNotImpl
 }

--- a/pkg/metadata/driver/netease/doc.go
+++ b/pkg/metadata/driver/netease/doc.go
@@ -1,0 +1,2 @@
+// Package netease contains code for retrieving metadata from netease API.
+package netease

--- a/pkg/metadata/driver/netease/song.go
+++ b/pkg/metadata/driver/netease/song.go
@@ -11,12 +11,14 @@ import (
 	"strings"
 )
 
+// SongRepository retrieves songs metadata from netease.
 type SongRepository struct {
 	pr      PlaylistRepository
 	BaseURL string
 	Client  http.Client
 }
 
+// GetSong retrieves the metadata of a song of a specific id from netease.
 func (r *SongRepository) GetSong(id song.ID) (song.Song, error) {
 	songs, err := r.GetSongs([]song.ID{id})
 	if err == nil && len(songs) != 0 {
@@ -25,6 +27,7 @@ func (r *SongRepository) GetSong(id song.ID) (song.Song, error) {
 	return song.Song{}, err
 }
 
+// GetSongs retrieves a bunch of songs metadata from netease.
 func (r *SongRepository) GetSongs(ids []song.ID) ([]song.Song, error) {
 	if len(ids) == 0 {
 		return nil, nil
@@ -92,6 +95,7 @@ func (r *SongRepository) GetSongs(ids []song.ID) ([]song.Song, error) {
 	return ss, nil
 }
 
+// GetSongsByQuery retrieves songs metadata by providing a keyword to netease.
 func (r *SongRepository) GetSongsByQuery(q string,
 	limit int, offset int) (map[song.ID]song.Song, int, error) {
 
@@ -133,7 +137,8 @@ func (r *SongRepository) GetSongsByQuery(q string,
 	return songs, respObj.Result.SongCount, nil
 }
 
-func (r *SongRepository) GetSongsByPlayListId(pid string,
+// GetSongsByPlaylistID retrieves songs metadata in a specific playlist.
+func (r *SongRepository) GetSongsByPlaylistID(pid string,
 	limit int, offset int) (map[song.ID]song.Song, int, error) {
 	req, err := http.NewRequest("GET",
 		fmt.Sprintf("%s/playlist/detail?id=%s", r.BaseURL, pid), nil)
@@ -184,6 +189,7 @@ func (r *SongRepository) GetSongsByPlayListId(pid string,
 	return songsMap, len(songIds), nil
 }
 
+// SearchByType shouldn't be a method of SongRepository, will fix soon.
 func (r *SongRepository) SearchByType(t song.SearchType, q string,
 	limit, offset int) ([]byte, error) {
 	req, err := http.NewRequest("GET",

--- a/pkg/metadata/exception/exception.go
+++ b/pkg/metadata/exception/exception.go
@@ -1,9 +1,0 @@
-package exception
-
-type NotImplementedError struct {
-	Err error
-}
-
-func (e *NotImplementedError) Error() string {
-	return "not implemented"
-}

--- a/pkg/metadata/intf/doc.go
+++ b/pkg/metadata/intf/doc.go
@@ -1,0 +1,2 @@
+// Package intf contains codes for interface layer, porting the application services to the outside world
+package intf

--- a/pkg/metadata/playlist/playlist.go
+++ b/pkg/metadata/playlist/playlist.go
@@ -1,8 +1,10 @@
+// Package playlist contains codes related to domain model Playlist
 package playlist
 
 import "github.com/xiaomi388/virtual-music-system/pkg/metadata/song"
 
-type PlayList struct {
+// Playlist contains metadata of a playlist, and what songs are in this playlist.
+type Playlist struct {
 	ID            song.ID     `json:"id"`
 	Name          string      `json:"name"`
 	CoverImageUrl string      `json:"cover_image_url"`

--- a/pkg/metadata/playlist/repo.go
+++ b/pkg/metadata/playlist/repo.go
@@ -2,7 +2,8 @@ package playlist
 
 import "github.com/xiaomi388/virtual-music-system/pkg/metadata/song"
 
+// Repository contains CRUD interfaces for Playlist entities.
 type Repository interface {
-	GetPlaylist(id song.ID) (PlayList, error)
-	GetPlaylistsByQuery(q string, limit int, offset int) (map[song.ID]PlayList, int, error)
+	GetPlaylist(id song.ID) (Playlist, error)
+	GetPlaylistsByQuery(q string, limit int, offset int) (map[song.ID]Playlist, int, error)
 }

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -1,4 +1,3 @@
-// metadata contains songs metadata including albums, artists, ...
 package metadata
 
 import (
@@ -6,6 +5,7 @@ import (
 	"github.com/xiaomi388/virtual-music-system/pkg/metadata/song"
 )
 
+// Service is an application service for CRUD of song-related metadata
 type Service struct {
 	SongRepo     song.Repository
 	PlayListRepo playlist.Repository
@@ -19,20 +19,22 @@ func (s *Service) GetArtistsByQuery() {
 
 }
 
-func (s *Service) GetPlaylistsByQuery(q string, limit int, offset int) ([]playlist.PlayList, int, error) {
+// GetPlaylistsByQuery returns playlist.Playlist entities to user.
+func (s *Service) GetPlaylistsByQuery(q string, limit int, offset int) ([]playlist.Playlist, int, error) {
 	playlistsMap, total, err := s.PlayListRepo.GetPlaylistsByQuery(q, limit, offset)
 	if err != nil {
 		return nil, 0, err
 	}
-	playLists := make([]playlist.PlayList, 0, len(playlistsMap))
+	playLists := make([]playlist.Playlist, 0, len(playlistsMap))
 	for _, p := range playlistsMap {
 		playLists = append(playLists, p)
 	}
 	return playLists, total, nil
 }
 
-func (s *Service) GetSongsByPlaylistId(q string, limit int, offset int) ([]song.Song, int, error) {
-	songMap, total, err := s.SongRepo.GetSongsByPlayListId(q, limit, offset)
+// GetSongsByPlaylistID returns a playlist.Playlist entity of a specific id.
+func (s *Service) GetSongsByPlaylistID(q string, limit int, offset int) ([]song.Song, int, error) {
+	songMap, total, err := s.SongRepo.GetSongsByPlaylistID(q, limit, offset)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -43,6 +45,7 @@ func (s *Service) GetSongsByPlaylistId(q string, limit int, offset int) ([]song.
 	return songs, total, nil
 }
 
+// GetSongsByQuery returns song.Song entities by searching a song keyword.
 func (s *Service) GetSongsByQuery(q string, limit int, offset int) ([]song.Song, int, error) {
 	songMap, total, err := s.SongRepo.GetSongsByQuery(q, limit, offset)
 	if err != nil {
@@ -55,11 +58,12 @@ func (s *Service) GetSongsByQuery(q string, limit int, offset int) ([]song.Song,
 	return songs, total, nil
 }
 
-func (s *Service) GetPlayListById(pid string) (playlist.PlayList, error) {
-	playList, err := s.PlayListRepo.GetPlaylist(song.ID(pid))
+// GetPlaylistByID returns a playlist.Playlist entity of a specific id.
+func (s *Service) GetPlaylistByID(pid string) (playlist.Playlist, error) {
+	pl, err := s.PlayListRepo.GetPlaylist(song.ID(pid))
 	if err != nil {
-		return playList, err
+		return pl, err
 	}
 
-	return playList, nil
+	return pl, nil
 }

--- a/pkg/metadata/song/repo.go
+++ b/pkg/metadata/song/repo.go
@@ -1,8 +1,10 @@
+// Package song contains codes related to domain model Song
 package song
 
+// SearchType represents kinds of metadata available for being used to search.
 type SearchType int
 
-//搜索类型: 默认为 1 即单曲 , 取值意义 : 1: 单曲, 10: 专辑, 100: 歌手,
+// 搜索类型: 默认为 1 即单曲 , 取值意义 : 1: 单曲, 10: 专辑, 100: 歌手,
 //		1000: 歌单, 1002: 用户, 1004: MV, 1006: 歌词, 1009: 电台, 1014: 视频, 1018:综合
 const (
 	SearchTypeSong     SearchType = 1
@@ -17,9 +19,10 @@ const (
 	SearchTypeMultiple SearchType = 1018
 )
 
+// Repository provides CRUD interfaces for Song entities.
 type Repository interface {
 	GetSong(id ID) (Song, error)
 	GetSongsByQuery(q string, limit int, offset int) (map[ID]Song, int, error)
-	GetSongsByPlayListId(pid string, limit int, offset int) (map[ID]Song, int, error)
+	GetSongsByPlaylistID(pid string, limit int, offset int) (map[ID]Song, int, error)
 	SearchByType(t SearchType, q string, limit, offset int) ([]byte, error)
 }

--- a/pkg/metadata/song/song.go
+++ b/pkg/metadata/song/song.go
@@ -1,7 +1,9 @@
 package song
 
+// ID is the type of Song.ID.
 type ID string
 
+// Song contains the metadata of a song.
 type Song struct {
 	ID         ID     `json:"id"`
 	Name       string `json:"name"`

--- a/pkg/song/driver/doc.go
+++ b/pkg/song/driver/doc.go
@@ -1,0 +1,2 @@
+// Package driver contains drivers implementing interfaces like LocalRepo, RemoteRepo, etc.
+package driver

--- a/pkg/song/driver/file.go
+++ b/pkg/song/driver/file.go
@@ -6,10 +6,14 @@ import (
 	"path/filepath"
 )
 
+// FileRepository implements model.LocalRepository.
+// It stores songs in the local file system.
 type FileRepository struct {
 	RootDir string
 }
 
+// GetSongByNameArtist get a song from the local file system
+// by the name and artist of the song.
 func (r *FileRepository) GetSongByNameArtist(name string, artist string) (model.Song, error) {
 	fp := filepath.Join(r.RootDir, artist, name+".mp3")
 
@@ -22,6 +26,7 @@ func (r *FileRepository) GetSongByNameArtist(name string, artist string) (model.
 	}
 }
 
+// CopySongFrom copies a song file located in filePath to "RepoRootDir/name/artist/name_artist.mp3".
 func (r *FileRepository) CopySongFrom(filePath string, name string, artist string) (model.Song, error) {
 	dirPath := filepath.Join(r.RootDir, artist)
 	_ = os.MkdirAll(dirPath, 0755)

--- a/pkg/song/driver/youtube.go
+++ b/pkg/song/driver/youtube.go
@@ -6,9 +6,12 @@ import (
 	"os/exec"
 )
 
+// YoutubeRepository implements model.RemoteRepository.
+// It retrieve songs from youtube.
 type YoutubeRepository struct {
 }
 
+// GetSongByNameArtist get a song from youtube by a song's name and artist name.
 func (r *YoutubeRepository) GetSongByNameArtist(name string, artist string) (filePath string, err error) {
 	fileName := fmt.Sprintf("/tmp/%s_%s", name, artist)
 	filePath = fileName + ".mp3"

--- a/pkg/song/intf/doc.go
+++ b/pkg/song/intf/doc.go
@@ -1,0 +1,2 @@
+// Package intf contains codes for interface layer, porting the application services to the outside world
+package intf

--- a/pkg/song/intf/httpsrv.go
+++ b/pkg/song/intf/httpsrv.go
@@ -3,11 +3,13 @@ package intf
 import "github.com/xiaomi388/virtual-music-system/pkg/song"
 import "github.com/gin-gonic/gin"
 
+// HTTPService is a HTTP adapter to Service
 type HTTPService struct {
 	Service *song.Service
 	GE      *gin.Engine
 }
 
+// GetSongByNameArtist ports the application service Service.GetSongByNameArtist by using HTTP
 func (s *HTTPService) GetSongByNameArtist(c *gin.Context) {
 	name := c.Query("name")
 	artist := c.Query("artist")
@@ -19,7 +21,7 @@ func (s *HTTPService) GetSongByNameArtist(c *gin.Context) {
 	c.File(song.FilePath)
 }
 
-// not threading safe
+// Register creates routes from url paths to handlers
 func (s *HTTPService) Register() {
 	s.GE.GET("/v1/song", s.GetSongByNameArtist)
 }

--- a/pkg/song/model/doc.go
+++ b/pkg/song/model/doc.go
@@ -1,0 +1,2 @@
+// Package model contains domain models in the song streaming context
+package model

--- a/pkg/song/model/repo.go
+++ b/pkg/song/model/repo.go
@@ -1,9 +1,12 @@
 package model
 
+// RemoteRepository retrieves songs content from a remote source
 type RemoteRepository interface {
 	GetSongByNameArtist(name string, artist string) (filePath string, err error)
 }
 
+// LocalRepository stores Song entities in the local environment
+// for quickly accessing by clients
 type LocalRepository interface {
 	GetSongByNameArtist(name string, artist string) (Song, error)
 	CopySongFrom(filePath string, name string, artist string) (Song, error)

--- a/pkg/song/model/song.go
+++ b/pkg/song/model/song.go
@@ -1,7 +1,9 @@
 package model
 
+// ID is the id of a Song entity
 type ID string
 
+// Song contains a song file metadata
 type Song struct {
 	ID       ID
 	Name     string

--- a/pkg/song/service.go
+++ b/pkg/song/service.go
@@ -1,3 +1,4 @@
+// Package song contains business logic related to streaming songs.
 package song
 
 import (
@@ -6,11 +7,13 @@ import (
 	"github.com/xiaomi388/virtual-music-system/pkg/song/model"
 )
 
+// Service provides application services related to song streaming.
 type Service struct {
 	LocalRepo   model.LocalRepository
 	RemoteRepos []model.RemoteRepository
 }
 
+// GetSongByNameArtist gets a song by its name and artist name.
 func (s *Service) GetSongByNameArtist(name string, artist string) (model.Song, error) {
 	song, err := s.LocalRepo.GetSongByNameArtist(name, artist)
 	if err != nil {
@@ -21,9 +24,8 @@ func (s *Service) GetSongByNameArtist(name string, artist string) (model.Song, e
 		return song, nil
 	}
 
-	// song not found
-	// FIXME: only trigger download one time if
-	// many users request a same song at the same time
+	// If the song is not in the local repo, retrieve it from remote.
+	// BUG(xiaomi388): May trigger download multiple times if many users request a same song at the same time.
 	var fp string
 	for _, rr := range s.RemoteRepos {
 		fp, err = rr.GetSongByNameArtist(name, artist)


### PR DESCRIPTION
The current project doesn't have completed comments explaining every
exported function, method, and variable. Besides, there are some
naming like `PlayListId`, which does not conform to Golang naming
convention as it suggests that abbreviation should all be uppercase or
lowercase. Also, playlist is a single word. Therefore `PlaylistID` seems
to be a better choice.